### PR TITLE
Fix encoding error on Python +3.8

### DIFF
--- a/main.py
+++ b/main.py
@@ -146,7 +146,7 @@ if __name__ == "__main__":
         output = output_dir + output + output_format
         print("Converting {} to {} ...".format(api_doc, output))
         doc_format: str = api_doc.rsplit('.')[-1]
-        with open(api_doc, 'r') as f:
+        with open(api_doc, 'rb') as f:
             doc_data: AnyStr = f.read()
 
         soup: BeautifulSoup = BeautifulSoup(doc_data, features="html.parser")


### PR DESCRIPTION
```sh
❯ python main.py 
Converting api/reascripthelp.html to vscode_snippets/reascript.code-snippets ...
Build of vscode_snippets/reascript.code-snippets done !
Converting api/reaper-videoprocessor-docs.USDocML to vscode_snippets/reascript_vp.code-snippets ...
Build of vscode_snippets/reascript_vp.code-snippets done !
Converting api/reaper-apidocs.USDocML to vscode_snippets/reascript_usdoc.code-snippets ...
Build of vscode_snippets/reascript_usdoc.code-snippets done !
Converting api/ultraschall.USDocML to vscode_snippets/ultraschall.code-snippets ...
Traceback (most recent call last):
  File "main.py", line 150, in <module>
    doc_data: AnyStr = f.read()
  File "/usr/lib/python3.8/codecs.py", line 322, in decode
    (result, consumed) = self._buffer_decode(data, self.errors, final)
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb0 in position 1688214: invalid start byte
```

https://stackoverflow.com/questions/42339876/error-unicodedecodeerror-utf-8-codec-cant-decode-byte-0xff-in-position-0-in